### PR TITLE
Ported titanxstall test to moderngpu mergesort

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "moderngpu"]
+	path = moderngpu
+	url = git@github.com:moderngpu/moderngpu

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,20 @@ CXXFLAGS += -std=c++98 -O3
 
 CXXFLAGS += -Wall
 
-CUFLAGS += --compiler-options $(subst $(space),$(comma),$(strip $(CXXFLAGS)))
+CUFLAGS += --compiler-options $(subst $(space),$(comma),$(strip $(CXXFLAGS))) -Xptxas="-v"
 
-all: titanxstall
+all: titanxstall titanxstall_moderngpu
+
+titanxstall_moderngpu: titanxstall_moderngpu.cu
+	nvcc -std=c++11 -Xptxas="-v" --expt-extended-lambda -arch sm_52 -I moderngpu/src -O2 -use_fast_math -o $@ $<
+
 
 test: titanxstall
 	./titanxstall
 clean:
 	rm -f titanxstall
+	rm -f titanxstall_moderngpu
 
 %: %.cu cached_alloc.h
-	nvcc $(CPPFLAGS) $(CUFLAGS) $(LDFLAGS) $(LDLIBS) -o $@ $<
+	nvcc -arch sm_52 $(CPPFLAGS) $(CUFLAGS) $(LDFLAGS) $(LDLIBS) -o $@ $<
 

--- a/titanxstall_moderngpu.cu
+++ b/titanxstall_moderngpu.cu
@@ -1,0 +1,84 @@
+/// Copyright (C) 2016 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+/// License: GPLv3
+
+#include <iostream>
+#include <moderngpu/kernel_mergesort.hxx>
+#include <moderngpu/transform.hxx>
+#include <moderngpu/tuple.hxx>
+
+#define restrict __restrict__
+
+typedef unsigned int uint;
+typedef unsigned int hashKey;
+typedef ushort4 particleinfo;
+
+MGPU_HOST_DEVICE ushort type(particleinfo info)
+{ return info.x; }
+
+MGPU_HOST_DEVICE uint id(particleinfo info)
+{ return (uint)(info.z) | ((uint)(info.w) << 16); }
+
+#define PART_FLAG_SHIFT	3
+#define PART_TYPE_MASK	((1<<PART_FLAG_SHIFT)-1)
+#define PART_TYPE(f) (type(f) & PART_TYPE_MASK)
+
+using namespace mgpu;
+
+int main()
+{
+  standard_context_t context;
+
+  uint numParticles = 5*1024*1024;
+  
+  typedef tuple<hashKey, particleinfo> key_t;
+  mem_t<key_t> keys(numParticles, context);
+  mem_t<int> partidx(numParticles, context);
+
+  int counter = 0;
+    
+  while(true)
+  {
+    // Prepare the things to sort.
+    key_t* keys_data = keys.data();
+    int* partidx_data = partidx.data();
+
+    transform([=]MGPU_DEVICE(int index) {
+      partidx_data[index] = index;
+
+      // Include some hash of the counter.
+        keys_data[index] = key_t(
+          index / 17 + (counter % (17 & index)),
+        particleinfo {
+          (ushort)(index % 4),
+          0,
+          (ushort)(0xffff & index),
+          (ushort)(index>> 16)
+        }
+      );
+    }, numParticles, context);
+  
+    // returns a < b.
+    auto comp = []MGPU_DEVICE(key_t a, key_t b) -> bool {
+      auto ha = get<0>(a), hb = get<0>(b);
+      auto pa = get<1>(a), pb = get<1>(b);
+      bool result;
+      if(ha == hb) {
+        if(PART_TYPE(pa) == PART_TYPE(pb))
+          result = id(pa) < id(pb);
+        else
+          result = PART_TYPE(pa) < PART_TYPE(pb);
+      } else
+        result = ha < hb;
+      return result;
+    };
+
+    // This is a big structure so choose a smaller grain size than the default.
+    typedef launch_params_t<256, 3> launch_t;
+    mergesort<launch_t>(keys_data, partidx_data, numParticles, comp, context);
+    
+    if(0 == counter % 100) printf("iteration %d\n", counter);
+    ++counter;
+  }
+}
+
+


### PR DESCRIPTION
I forked your repo and submoduled moderngpu into it. It's not quite literally what you had--my mergesort reuses the input array to ping-pong the passes, so it only accepts pointers, not iterators. So I have a transform() call that combines the hash and the particleinfo into a tuple<>. I believe thrust does this internally, as I cannot see how it can ping-pong between your provided zip-iterator and a by-value store that it creates on its side.

The hash is a function of counter to keep things changing. Anyways, I've run out to 25,000 iterations now.
